### PR TITLE
Add Tkinter LLM runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# Tiny Planet LLM App
+
+This repository includes a small Tkinter-based application to run a local language model on Windows using [Ollama](https://ollama.ai/). The GUI lets you enter a prompt, choose a folder to process, select the model name (or path) and pick an output format.
+
+## Requirements
+- Python 3.10 or newer
+- `python-docx` if you want to save output as `.docx`
+
+The application will attempt to install the `ollama` Python package automatically
+the first time it is launched so it can communicate with the local Ollama server.
+Make sure Ollama 0.8.0 or newer is installed and running. You can also install
+the dependencies upfront by running:
+```bash
+pip install ollama python-docx
+```
+
+## Usage
+1. Run the application:
+```bash
+python llm_app.py
+```
+2. Enter a prompt and select the folder that contains the files you want processed.
+3. The model field is pre-filled with the example name/path `gemma-3-12b-it-Q4_K_M.gguf`. You can enter a model **name** that already exists in Ollama or provide a path to a local `.gguf` file. If a path is supplied, the app will register it as a model automatically.
+4. Pick the desired output format (text or docx) and click **Start** to begin the loop. After each iteration you will be asked whether you want to run again.
+
+Outputs are saved in a new `llm_output` folder within the selected directory.
+
+## Building a Windows executable
+If you want to distribute the application as a single `.exe` file you can use
+[PyInstaller](https://pyinstaller.org/).
+
+Install the dependencies and PyInstaller:
+```bash
+pip install -r requirements.txt
+pip install pyinstaller
+```
+
+Run the provided batch script to create the executable:
+```cmd
+build_exe.bat
+```
+The `llm_app.exe` binary will appear in the `dist` folder.

--- a/build_exe.bat
+++ b/build_exe.bat
@@ -1,0 +1,3 @@
+@echo off
+REM Build llm_app.exe using PyInstaller
+pyinstaller --noconsole --onefile llm_app.py

--- a/llm_app.py
+++ b/llm_app.py
@@ -1,0 +1,179 @@
+import os
+import subprocess
+import tempfile
+import tkinter as tk
+from tkinter import filedialog, messagebox
+from pathlib import Path
+
+# Use Ollama to run the local LLM. Install the `ollama` package on first run if
+# needed so that the GUI can communicate with the local Ollama server.
+try:
+    import ollama
+except ImportError:
+    import sys
+    try:
+        subprocess.check_call([
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "ollama",
+        ])
+        import ollama  # retry after installation
+    except Exception as e:  # keep a stub so we can report the error in the UI
+        ollama = None
+        print("Failed to install the ollama package:", e)
+        print("Please install it manually with 'pip install ollama'")
+
+
+class LLMApp:
+    def __init__(self, master):
+        self.master = master
+        master.title("LLM Task Runner")
+
+        tk.Label(master, text="Prompt:").grid(row=0, column=0, sticky='w')
+        self.prompt_entry = tk.Entry(master, width=60)
+        self.prompt_entry.grid(row=0, column=1, padx=5, pady=5)
+
+        tk.Label(master, text="Folder:").grid(row=1, column=0, sticky='w')
+        self.folder_entry = tk.Entry(master, width=60)
+        self.folder_entry.grid(row=1, column=1, padx=5, pady=5)
+        tk.Button(master, text="Browse", command=self.browse_folder).grid(row=1, column=2)
+
+        tk.Label(master, text="Model path:").grid(row=2, column=0, sticky='w')
+        self.model_entry = tk.Entry(master, width=60)
+        self.model_entry.grid(row=2, column=1, padx=5, pady=5)
+        self.model_entry.insert(0, r"C:\Users\Pavel\Desktop\Patronus\gemma-3-12b-it-Q4_K_M.gguf")
+        tk.Button(master, text="Browse", command=self.browse_model).grid(row=2, column=2)
+
+        tk.Label(master, text="Output format:").grid(row=3, column=0, sticky='w')
+        self.format_var = tk.StringVar(value='text')
+        tk.Radiobutton(master, text="Text", variable=self.format_var, value='text').grid(row=3, column=1, sticky='w')
+        tk.Radiobutton(master, text="Docx", variable=self.format_var, value='docx').grid(row=3, column=1)
+
+        tk.Button(master, text="Start", command=self.start_loop).grid(row=4, column=1, pady=10)
+
+    def browse_folder(self):
+        folder = filedialog.askdirectory()
+        if folder:
+            self.folder_entry.delete(0, tk.END)
+            self.folder_entry.insert(0, folder)
+
+    def browse_model(self):
+        path = filedialog.askopenfilename(filetypes=[('Model files', '*.gguf'), ('All files', '*.*')])
+        if path:
+            self.model_entry.delete(0, tk.END)
+            self.model_entry.insert(0, path)
+
+    def ensure_model_available(self, model_or_path: str) -> str | None:
+        """Return an Ollama model name, creating one from a local path if needed."""
+        if not model_or_path:
+            messagebox.showwarning("Warning", "Model name is empty")
+            return None
+
+        # If the value looks like a path to a local GGUF file, create a temporary
+        # model for it. Ollama's API identifies models by name and can't accept a
+        # raw file path directly.
+        if os.path.isfile(model_or_path):
+            # Use the file name without extension as the model name
+            name = Path(model_or_path).stem
+            try:
+                existing = [m["name"] for m in ollama.list()["models"]]
+            except Exception:
+                existing = []
+            if name not in existing:
+                modelfile_contents = f"FROM {model_or_path}"
+                with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+                    tmp.write(modelfile_contents)
+                    tmp_path = tmp.name
+                try:
+                    ollama.create(model=name, path=tmp_path)
+                except Exception as e:
+                    messagebox.showerror("Error", f"Failed to register model: {e}")
+                    os.unlink(tmp_path)
+                    return None
+                os.unlink(tmp_path)
+            return name
+
+        return model_or_path
+
+    def load_model(self):
+        if ollama is None:
+            messagebox.showerror("Error", "The 'ollama' package is not available")
+            return False
+        self.model_name = self.ensure_model_available(self.model_entry.get().strip())
+        return bool(self.model_name)
+
+    def run_llm(self, prompt):
+        if not self.load_model():
+            return ""
+        try:
+            result = ollama.generate(model=self.model_name, prompt=prompt)
+            if isinstance(result, dict):
+                return result.get('response', '')
+            return str(result)
+        except Exception as e:
+            messagebox.showerror("Error", f"Ollama failed: {e}")
+            return ""
+
+    def process_folder(self, folder, prompt):
+        files = list(Path(folder).glob('*'))
+        results = []
+        for f in files:
+            file_prompt = prompt
+            if f.suffix.lower() == '.txt':
+                try:
+                    content = f.read_text(encoding='utf-8')
+                    file_prompt = f"{prompt}\n{content}"
+                except Exception:
+                    pass
+            response = self.run_llm(file_prompt)
+            results.append(f"{f.name}:\n{response}\n")
+        return ''.join(results)
+
+    def save_output(self, text):
+        folder = self.folder_entry.get()
+        if not folder:
+            folder = os.getcwd()
+        output_path = Path(folder) / 'llm_output'
+        output_path.mkdir(exist_ok=True)
+        if self.format_var.get() == 'docx':
+            try:
+                from docx import Document
+            except ImportError:
+                messagebox.showerror("Error", "python-docx not installed")
+                return
+            doc = Document()
+            doc.add_paragraph(text)
+            file_path = output_path / 'result.docx'
+            doc.save(file_path)
+        else:
+            file_path = output_path / 'result.txt'
+            with open(file_path, 'w', encoding='utf-8') as f:
+                f.write(text)
+        messagebox.showinfo("Saved", f"Result saved to {file_path}")
+
+    def start_loop(self):
+        prompt = self.prompt_entry.get()
+        folder = self.folder_entry.get()
+        if not prompt:
+            messagebox.showwarning("Warning", "Prompt is empty")
+            return
+        if not folder:
+            messagebox.showwarning("Warning", "Folder not selected")
+            return
+        while True:
+            processed = self.process_folder(folder, prompt)
+            self.save_output(processed)
+            if not messagebox.askyesno("Continue", "Run again?"):
+                break
+
+
+def main():
+    root = tk.Tk()
+    app = LLMApp(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+ollama
+python-docx


### PR DESCRIPTION
## Summary
- add a small Tkinter interface to run a local LLM model
- document dependencies and usage in README
- fix model registration for Ollama

## Testing
- `python -m py_compile llm_app.py`


------
https://chatgpt.com/codex/tasks/task_e_683e9234925483219b7bb64f9aa00baf